### PR TITLE
make build.py compatible with Python 2 or 3

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Compiles student and teacher PDFs for each LaTeX source file."""
+from __future__ import print_function
 
 import os
 import shutil
@@ -13,23 +14,23 @@ CLEAN = True
 
 def latex(name, suff):
     """Run latex and rename pdf."""
-    print "  " + suff + "...",
+    print("  " + suff + "...", end=' ')
     sys.stdout.flush()
     # check timestamp
     pdf = name[:-4] + "_" + suff + ".pdf"
     if os.path.isfile(pdf):
         if os.path.getmtime(pdf) > os.path.getmtime(name):
-            print "SKIP"
+            print("SKIP")
             return
     # pass suffix to latex
     cmd = LATEX + " '\\def\\" + suff + "{}\\input{_TEMP_.tex}'"
     status = os.system(cmd + " > _TEMP_1.run")
     status = os.system(cmd + " > _TEMP_2.run")
     if status == 0:
-        print "OK"
+        print("OK")
         os.rename("_TEMP_.pdf", pdf)
     else:
-        print "ERROR"
+        print("ERROR")
         return status
     # clean up temp files
     if CLEAN:
@@ -43,7 +44,7 @@ def build(path, name):
     """Build the given source file."""
     if name == "_TEMP_.tex":
         return
-    print os.path.join(path, name)
+    print(os.path.join(path, name))
     if "\\documentclass" in open(name).read():
         # copy original activity file
         shutil.copyfile(name, "_TEMP_.tex")
@@ -89,12 +90,12 @@ def main(pattern):
                 if pattern == "clean" and name.endswith(".pdf"):
                     if name[-12:-4] in ["_Student", "_Teacher"]:
                         pathname = os.path.join(path, name)
-                        print pathname
+                        print(pathname)
                         os.remove(pathname)
 
 if __name__ == "__main__":
     if len(sys.argv) == 2:
         main(sys.argv[1])
     else:
-        print "Usage: build.py {all | clean | NAME}"
-        print "NAME is any substring of the file(s)"
+        print("Usage: build.py {all | clean | NAME}")
+        print("NAME is any substring of the file(s)")


### PR DESCRIPTION
I used futurize on build.py to update it to work with Python 3, but remain backwards compatible with Python 2. So it will run on both. For build.py this meant changing print statements (python 2) to print function calls (python 3). Then, to make the print function calls work in python 2, importing print_function from the __future__ module. All the rest stays the same.

This does introduce a new demand/requirement on development. Python 3 should be used in build.py rather than Python 2. Then, to maintain backwards compatibility with Python 2, run pasteurize.

Another approach is to use modernize instead of futurize/pasteurize to keep the Python 2.7 syntax, but to allow Python 3 to run it.

And the other obvious decision is to say, not going to support Python 3 :)