### PR TITLE
Attempt using GitHub Actions to auto-build PDFs

### DIFF
--- a/.github/workflows/pdf-build.yml
+++ b/.github/workflows/pdf-build.yml
@@ -1,0 +1,29 @@
+---
+name: Build PDF Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  Build:
+    name: Build PDF release bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install texlive-latex-recommended texlive-latex-extra
+      - name: Build PDFs
+        run: |
+          ./build.py all
+          find . '(' -name "*_Student.pdf" -or -name "*_Teacher.pdf" ')' -exec zip -g PDF.zip {} \;
+      - name: Set GitHub auth token
+        run: |
+          gh config set -h github.com oauth_token "${{ secrets.GITHUB_TOKEN }}"
+      - name: Create updated release
+        run: |
+          gh release delete cspogil-latest -y || true
+          git push --delete origin cspogil-latest || true
+          gh release create cspogil-latest PDF.zip

--- a/CS0/Act11/product-join.tex
+++ b/CS0/Act11/product-join.tex
@@ -1,5 +1,8 @@
 \model{Product and Join}
 
+% subscript for relational algebra
+\newcommand{\sub}[1]{$_{\mbox{\small #1}}$}
+
 Mathematically speaking, we combine tables by ``multiplying'' them.
 Every row in the right table is appended to every row in the left table:
 

--- a/CS0/Act11/select-project.tex
+++ b/CS0/Act11/select-project.tex
@@ -1,5 +1,8 @@
 \model{Select and Project}
 
+% subscript for relational algebra
+\newcommand{\sub}[1]{$_{\mbox{\small #1}}$}
+
 In relational databases, \emph{data} is organized as tables.
 We use \emph{SELECT} to work with rows and \emph{PROJECT} to work with columns.
 The names of the columns are called the \emph{schema}.


### PR DESCRIPTION
I saw a mention of this repo earlier and wanted to see if I could apply a trick we use for the UUG presentations repository. After a few small changes, this uses GitHub Actions to run your `build.py`, assemble a zip of the resulting PDFs, and publish them as a release artifact on GitHub. The zip is not committed, so it won't explode the size of your repository. Also, because it deletes the previous release and publishes a new one on each push to `master`, you end up with a fairly stable URL to link to: https://github.com/ChrisMayfield/cspogil/releases/download/cspogil-latest/PDF.zip (after the first run completes).

If you want to see what a run looks like, my misfires are all archived here: https://github.com/ripleymj/cspogil/actions

And if this isn't a direction you want to take the project, no hard feelings if you just close the PR.